### PR TITLE
Pre-create target folders as necessary

### DIFF
--- a/src/ch/ahdis/fhir/r4/test/TutorialMapTests.java
+++ b/src/ch/ahdis/fhir/r4/test/TutorialMapTests.java
@@ -49,27 +49,27 @@ public class TutorialMapTests {
 		// FIXME: put here the path to build directory of the checkout source of forge
 		TestingUtilities.fixedpath = "//Users//oliveregger//fhir//trunk//build";
 		if (context == null)
-				context = SimpleWorkerContext
-					.fromPack(Utilities.path(TestingUtilities.home(), "publish", "igpack.zip"));
+			context = SimpleWorkerContext
+			.fromPack(Utilities.path(TestingUtilities.home(), "publish", "igpack.zip"));
 
 		TestingUtilities.context = new SimpleWorkerContext(context);
 		fhirPathEngine = new FHIRPathEngine(TestingUtilities.context);
 		structureMapUtilites = new StructureMapUtilities(TestingUtilities.context, maps, mappingServices);
-		
-	    if (setupTargetFolders) {
-	        return;
-	    }
-	    setupTargetFolders = true;
-        DirectoryStream<Path> dirStream = Files.newDirectoryStream(Paths.get(path.replace("\\", File.separator)));
-        for ( Path p : dirStream )
-        {
-            if ( p.toFile().isDirectory() )
-            {
-                Path pathTarget = Paths.get(Utilities.path(getPathTarget(p.getFileName().toString())));
-                if (Files.notExists(pathTarget))
-                	Files.createDirectories(pathTarget);
-            }
-        }
+
+		if (setupTargetFolders) {
+			return;
+		}
+		setupTargetFolders = true;
+		DirectoryStream<Path> dirStream = Files.newDirectoryStream(Paths.get(path.replace("\\", File.separator)));
+		for ( Path p : dirStream )
+		{
+			if ( p.toFile().isDirectory() )
+			{
+				Path pathTarget = Paths.get(Utilities.path(getPathTarget(p.getFileName().toString())));
+				if (Files.notExists(pathTarget))
+					Files.createDirectories(pathTarget);
+			}
+		}
 	}
 	
 	/**

--- a/src/ch/ahdis/fhir/r4/test/TutorialMapTests.java
+++ b/src/ch/ahdis/fhir/r4/test/TutorialMapTests.java
@@ -10,6 +10,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.context.SimpleWorkerContext;
@@ -37,6 +41,8 @@ public class TutorialMapTests {
 
 	final private String path = ".\\maptutorial\\";
 	static private SimpleWorkerContext context;
+	private static boolean setupTargetFolders = false;
+	
 	
 	@Before 
 	public void setupTest() throws FileNotFoundException, IOException, FHIRException {
@@ -49,6 +55,21 @@ public class TutorialMapTests {
 		TestingUtilities.context = new SimpleWorkerContext(context);
 		fhirPathEngine = new FHIRPathEngine(TestingUtilities.context);
 		structureMapUtilites = new StructureMapUtilities(TestingUtilities.context, maps, mappingServices);
+		
+	    if (setupTargetFolders) {
+	        return;
+	    }
+	    setupTargetFolders = true;
+        DirectoryStream<Path> dirStream = Files.newDirectoryStream(Paths.get(path.replace("\\", File.separator)));
+        for ( Path p : dirStream )
+        {
+            if ( p.toFile().isDirectory() )
+            {
+                Path pathTarget = Paths.get(Utilities.path(getPathTarget(p.getFileName().toString())));
+                if (Files.notExists(pathTarget))
+                	Files.createDirectories(pathTarget);
+            }
+        }
 	}
 	
 	/**


### PR DESCRIPTION
This enables tests to run out of the box after a clone.

I tried using @BeforeClass a go to ensure the setup is run only once, but that requires your method to be static and brings in pain. I have no idea why JUnit doesn't have a proper @Setup annotation.